### PR TITLE
gen-object-api

### DIFF
--- a/FlatGeobuf/Column.go
+++ b/FlatGeobuf/Column.go
@@ -6,6 +6,62 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 
+type ColumnT struct {
+	Name string
+	Type ColumnType
+	Title string
+	Description string
+	Width int32
+	Precision int32
+	Scale int32
+	Nullable bool
+	Unique bool
+	PrimaryKey bool
+	Metadata string
+}
+
+func (t *ColumnT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	if t == nil { return 0 }
+	nameOffset := builder.CreateString(t.Name)
+	titleOffset := builder.CreateString(t.Title)
+	descriptionOffset := builder.CreateString(t.Description)
+	metadataOffset := builder.CreateString(t.Metadata)
+	ColumnStart(builder)
+	ColumnAddName(builder, nameOffset)
+	ColumnAddType(builder, t.Type)
+	ColumnAddTitle(builder, titleOffset)
+	ColumnAddDescription(builder, descriptionOffset)
+	ColumnAddWidth(builder, t.Width)
+	ColumnAddPrecision(builder, t.Precision)
+	ColumnAddScale(builder, t.Scale)
+	ColumnAddNullable(builder, t.Nullable)
+	ColumnAddUnique(builder, t.Unique)
+	ColumnAddPrimaryKey(builder, t.PrimaryKey)
+	ColumnAddMetadata(builder, metadataOffset)
+	return ColumnEnd(builder)
+}
+
+func (rcv *Column) UnPackTo(t *ColumnT) {
+	t.Name = string(rcv.Name())
+	t.Type = rcv.Type()
+	t.Title = string(rcv.Title())
+	t.Description = string(rcv.Description())
+	t.Width = rcv.Width()
+	t.Precision = rcv.Precision()
+	t.Scale = rcv.Scale()
+	t.Nullable = rcv.Nullable()
+	t.Unique = rcv.Unique()
+	t.PrimaryKey = rcv.PrimaryKey()
+	t.Metadata = string(rcv.Metadata())
+}
+
+func (rcv *Column) UnPack() *ColumnT {
+	if rcv == nil { return nil }
+	t := &ColumnT{}
+	rcv.UnPackTo(t)
+	return t
+}
+
 type Column struct {
 	_tab flatbuffers.Table
 }
@@ -14,13 +70,6 @@ func GetRootAsColumn(buf []byte, offset flatbuffers.UOffsetT) *Column {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
 	x := &Column{}
 	x.Init(buf, n+offset)
-	return x
-}
-
-func GetSizePrefixedRootAsColumn(buf []byte, offset flatbuffers.UOffsetT) *Column {
-	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &Column{}
-	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 

--- a/FlatGeobuf/Crs.go
+++ b/FlatGeobuf/Crs.go
@@ -6,6 +6,48 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 
+type CrsT struct {
+	Org string
+	Code int32
+	Name string
+	Description string
+	Wkt string
+	CodeString string
+}
+
+func (t *CrsT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	if t == nil { return 0 }
+	orgOffset := builder.CreateString(t.Org)
+	nameOffset := builder.CreateString(t.Name)
+	descriptionOffset := builder.CreateString(t.Description)
+	wktOffset := builder.CreateString(t.Wkt)
+	codeStringOffset := builder.CreateString(t.CodeString)
+	CrsStart(builder)
+	CrsAddOrg(builder, orgOffset)
+	CrsAddCode(builder, t.Code)
+	CrsAddName(builder, nameOffset)
+	CrsAddDescription(builder, descriptionOffset)
+	CrsAddWkt(builder, wktOffset)
+	CrsAddCodeString(builder, codeStringOffset)
+	return CrsEnd(builder)
+}
+
+func (rcv *Crs) UnPackTo(t *CrsT) {
+	t.Org = string(rcv.Org())
+	t.Code = rcv.Code()
+	t.Name = string(rcv.Name())
+	t.Description = string(rcv.Description())
+	t.Wkt = string(rcv.Wkt())
+	t.CodeString = string(rcv.CodeString())
+}
+
+func (rcv *Crs) UnPack() *CrsT {
+	if rcv == nil { return nil }
+	t := &CrsT{}
+	rcv.UnPackTo(t)
+	return t
+}
+
 type Crs struct {
 	_tab flatbuffers.Table
 }
@@ -14,13 +56,6 @@ func GetRootAsCrs(buf []byte, offset flatbuffers.UOffsetT) *Crs {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
 	x := &Crs{}
 	x.Init(buf, n+offset)
-	return x
-}
-
-func GetSizePrefixedRootAsCrs(buf []byte, offset flatbuffers.UOffsetT) *Crs {
-	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &Crs{}
-	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 

--- a/FlatGeobuf/Geometry.go
+++ b/FlatGeobuf/Geometry.go
@@ -6,6 +6,146 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 
+type GeometryT struct {
+	Ends []uint32
+	Xy []float64
+	Z []float64
+	M []float64
+	T []float64
+	Tm []uint64
+	Type GeometryType
+	Parts []*GeometryT
+}
+
+func (t *GeometryT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	if t == nil { return 0 }
+	endsOffset := flatbuffers.UOffsetT(0)
+	if t.Ends != nil {
+		endsLength := len(t.Ends)
+		GeometryStartEndsVector(builder, endsLength)
+		for j := endsLength - 1; j >= 0; j-- {
+			builder.PrependUint32(t.Ends[j])
+		}
+		endsOffset = builder.EndVector(endsLength)
+	}
+	xyOffset := flatbuffers.UOffsetT(0)
+	if t.Xy != nil {
+		xyLength := len(t.Xy)
+		GeometryStartXyVector(builder, xyLength)
+		for j := xyLength - 1; j >= 0; j-- {
+			builder.PrependFloat64(t.Xy[j])
+		}
+		xyOffset = builder.EndVector(xyLength)
+	}
+	zOffset := flatbuffers.UOffsetT(0)
+	if t.Z != nil {
+		zLength := len(t.Z)
+		GeometryStartZVector(builder, zLength)
+		for j := zLength - 1; j >= 0; j-- {
+			builder.PrependFloat64(t.Z[j])
+		}
+		zOffset = builder.EndVector(zLength)
+	}
+	mOffset := flatbuffers.UOffsetT(0)
+	if t.M != nil {
+		mLength := len(t.M)
+		GeometryStartMVector(builder, mLength)
+		for j := mLength - 1; j >= 0; j-- {
+			builder.PrependFloat64(t.M[j])
+		}
+		mOffset = builder.EndVector(mLength)
+	}
+	tOffset := flatbuffers.UOffsetT(0)
+	if t.T != nil {
+		tLength := len(t.T)
+		GeometryStartTVector(builder, tLength)
+		for j := tLength - 1; j >= 0; j-- {
+			builder.PrependFloat64(t.T[j])
+		}
+		tOffset = builder.EndVector(tLength)
+	}
+	tmOffset := flatbuffers.UOffsetT(0)
+	if t.Tm != nil {
+		tmLength := len(t.Tm)
+		GeometryStartTmVector(builder, tmLength)
+		for j := tmLength - 1; j >= 0; j-- {
+			builder.PrependUint64(t.Tm[j])
+		}
+		tmOffset = builder.EndVector(tmLength)
+	}
+	partsOffset := flatbuffers.UOffsetT(0)
+	if t.Parts != nil {
+		partsLength := len(t.Parts)
+		partsOffsets := make([]flatbuffers.UOffsetT, partsLength)
+		for j := 0; j < partsLength; j++ {
+			partsOffsets[j] = t.Parts[j].Pack(builder)
+		}
+		GeometryStartPartsVector(builder, partsLength)
+		for j := partsLength - 1; j >= 0; j-- {
+			builder.PrependUOffsetT(partsOffsets[j])
+		}
+		partsOffset = builder.EndVector(partsLength)
+	}
+	GeometryStart(builder)
+	GeometryAddEnds(builder, endsOffset)
+	GeometryAddXy(builder, xyOffset)
+	GeometryAddZ(builder, zOffset)
+	GeometryAddM(builder, mOffset)
+	GeometryAddT(builder, tOffset)
+	GeometryAddTm(builder, tmOffset)
+	GeometryAddType(builder, t.Type)
+	GeometryAddParts(builder, partsOffset)
+	return GeometryEnd(builder)
+}
+
+func (rcv *Geometry) UnPackTo(t *GeometryT) {
+	endsLength := rcv.EndsLength()
+	t.Ends = make([]uint32, endsLength)
+	for j := 0; j < endsLength; j++ {
+		t.Ends[j] = rcv.Ends(j)
+	}
+	xyLength := rcv.XyLength()
+	t.Xy = make([]float64, xyLength)
+	for j := 0; j < xyLength; j++ {
+		t.Xy[j] = rcv.Xy(j)
+	}
+	zLength := rcv.ZLength()
+	t.Z = make([]float64, zLength)
+	for j := 0; j < zLength; j++ {
+		t.Z[j] = rcv.Z(j)
+	}
+	mLength := rcv.MLength()
+	t.M = make([]float64, mLength)
+	for j := 0; j < mLength; j++ {
+		t.M[j] = rcv.M(j)
+	}
+	tLength := rcv.TLength()
+	t.T = make([]float64, tLength)
+	for j := 0; j < tLength; j++ {
+		t.T[j] = rcv.T(j)
+	}
+	tmLength := rcv.TmLength()
+	t.Tm = make([]uint64, tmLength)
+	for j := 0; j < tmLength; j++ {
+		t.Tm[j] = rcv.Tm(j)
+	}
+	t.Type = rcv.Type()
+	partsLength := rcv.PartsLength()
+	t.Parts = make([]*GeometryT, partsLength)
+	for j := 0; j < partsLength; j++ {
+		x := Geometry{}
+		rcv.Parts(&x, j)
+		t.Parts[j] = x.UnPack()
+	}
+}
+
+func (rcv *Geometry) UnPack() *GeometryT {
+	if rcv == nil { return nil }
+	t := &GeometryT{}
+	rcv.UnPackTo(t)
+	return t
+}
+
 type Geometry struct {
 	_tab flatbuffers.Table
 }
@@ -14,13 +154,6 @@ func GetRootAsGeometry(buf []byte, offset flatbuffers.UOffsetT) *Geometry {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
 	x := &Geometry{}
 	x.Init(buf, n+offset)
-	return x
-}
-
-func GetSizePrefixedRootAsGeometry(buf []byte, offset flatbuffers.UOffsetT) *Geometry {
-	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &Geometry{}
-	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 

--- a/columns.go
+++ b/columns.go
@@ -7,22 +7,18 @@ import (
 )
 
 type Columns struct {
-	names map[string]*FlatGeobuf.Column
-	ids   []*FlatGeobuf.Column
+	names map[string]*FlatGeobuf.ColumnT
+	ids   []*FlatGeobuf.ColumnT
 }
 
-func NewColumns(header *FlatGeobuf.Header) *Columns {
+func NewColumns(header *FlatGeobuf.HeaderT) *Columns {
+	names := make(map[string]*FlatGeobuf.ColumnT)
+	ids := make([]*FlatGeobuf.ColumnT, len(header.Columns))
 
-	names := make(map[string]*FlatGeobuf.Column)
-	colLen := header.ColumnsLength()
-	ids := make([]*FlatGeobuf.Column, colLen)
-
-	for i := 0; i < colLen; i++ {
-		var c FlatGeobuf.Column
-		header.Columns(&c, i)
-		name := string(c.Name())
-		names[name] = &c
-		ids[i] = &c
+	for i, column := range header.Columns {
+		name := column.Name
+		names[name] = column
+		ids[i] = column
 	}
 
 	return &Columns{
@@ -35,13 +31,13 @@ func (cols *Columns) String() string {
 	var b strings.Builder
 
 	for i, v := range cols.ids {
-		b.WriteString(fmt.Sprintf("%d: %s\n", i, string(v.Name())))
+		b.WriteString(fmt.Sprintf("%d: %s\n", i, string(v.Name)))
 	}
 
 	for k, v := range cols.names {
 		b.WriteString(k)
 		b.WriteString(" : ")
-		b.WriteString(v.Type().String())
+		b.WriteString(v.Type.String())
 		b.WriteString("\n")
 	}
 

--- a/feature.go
+++ b/feature.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Feature struct {
-	fgbFeature *FlatGeobuf.Feature
+	fgbFeature *FlatGeobuf.FeatureT
 	features   *Features
 }
 
-func NewFeature(fgbFeature *FlatGeobuf.Feature, features *Features) *Feature {
+func NewFeature(fgbFeature *FlatGeobuf.FeatureT, features *Features) *Feature {
 	feature := Feature{
 		fgbFeature: fgbFeature,
 		features:   features,
@@ -23,17 +23,17 @@ func NewFeature(fgbFeature *FlatGeobuf.Feature, features *Features) *Feature {
 }
 
 func (f *Feature) Geometry() (geom.T, error) {
-	geometry := f.fgbFeature.Geometry(nil)
+	geometry := f.fgbFeature.Geometry
 	geometryType := f.features.GeometryType()
 	if geometryType == FlatGeobuf.GeometryTypeUnknown {
-		geometryType = geometry.Type()
+		geometryType = geometry.Type
 	}
 
 	var newGeom geom.T
 	var err error
 
 	layout := f.features.Layout()
-	if geometry.PartsLength() > 0 {
+	if len(geometry.Parts) > 0 {
 		newGeom, err = parseMultiGeometry(geometry, layout, geometryType)
 	} else {
 		newGeom, err = parseSimpleGeometry(geometry, layout, geometryType)
@@ -56,7 +56,7 @@ func (f *Feature) Geometry() (geom.T, error) {
 }
 
 func (f *Feature) Properties() map[string]interface{} {
-	props := f.features.propertyDecoder.Decode(f.fgbFeature.PropertiesBytes())
+	props := f.features.propertyDecoder.Decode(f.fgbFeature.Properties)
 
 	return props
 }

--- a/features.go
+++ b/features.go
@@ -9,12 +9,12 @@ import (
 )
 
 type Features struct {
-	header          *FlatGeobuf.Header
+	header          *FlatGeobuf.HeaderT
 	r               io.Reader
 	propertyDecoder *PropertyDecoder
 }
 
-func NewFeatures(r io.Reader, header *FlatGeobuf.Header) *Features {
+func NewFeatures(r io.Reader, header *FlatGeobuf.HeaderT) *Features {
 	columns := NewColumns(header)
 	propertyDecoder := NewPropertyDecoder(columns)
 
@@ -48,14 +48,14 @@ func (fs *Features) Read() (*Feature, error) {
 	// TODO: handle errors
 	io.ReadFull(fs.r, b)
 
-	fgbFeature := FlatGeobuf.GetRootAsFeature(b, 0)
+	fgbFeature := FlatGeobuf.GetRootAsFeature(b, 0).UnPack()
 
 	feature := NewFeature(fgbFeature, fs)
 
 	return feature, nil
 }
 
-func (fs *Features) ReadAt(pos uint32) *FlatGeobuf.Feature {
+func (fs *Features) ReadAt(pos uint32) *FlatGeobuf.FeatureT {
 	//TODO: this cannot be implemented with a simple reader
 	return nil
 	//return FlatGeobuf.GetSizePrefixedRootAsFeature(fs.b, flatbuffers.UOffsetT(pos))
@@ -64,13 +64,13 @@ func (fs *Features) ReadAt(pos uint32) *FlatGeobuf.Feature {
 // TODO: check if header crs is never nil and defaults to 0 -> uknown as header.fbs
 // 		 also check if 0 is an acceptable value for go geom srid
 func (fs *Features) Crs() int {
-	crs := fs.header.Crs(nil)
+	crs := fs.header.Crs
 
 	if crs == nil {
 		return 0
 	}
 
-	return int(crs.Code())
+	return int(crs.Code)
 }
 
 func (fs *Features) Layout() geom.Layout {
@@ -78,5 +78,5 @@ func (fs *Features) Layout() geom.Layout {
 }
 
 func (fs *Features) GeometryType() FlatGeobuf.GeometryType {
-	return fs.header.GeometryType()
+	return fs.header.GeometryType
 }

--- a/flatgeobuffer.go
+++ b/flatgeobuffer.go
@@ -37,7 +37,7 @@ func Version(fileMagicBytes []byte) (string, error) {
 }
 
 type FGBReader struct {
-	header   *FlatGeobuf.Header
+	header   *FlatGeobuf.HeaderT
 	features *Features
 	prt      *index.PackedRTree
 }
@@ -60,18 +60,18 @@ func NewFGB(r io.Reader) (*FGBReader, error) {
 	}
 
 	var indexLength uint64
-	header := FlatGeobuf.GetRootAsHeader(buffer, 0)
+	header := FlatGeobuf.GetRootAsHeader(buffer, 0).UnPack()
 	fgb.header = header
 
-	if header.IndexNodeSize() != 0 {
-		indexLength, err = index.CalcTreeSize(header.FeaturesCount(), header.IndexNodeSize())
+	if header.IndexNodeSize != 0 {
+		indexLength, err = index.CalcTreeSize(header.FeaturesCount, header.IndexNodeSize)
 		buffer = make([]byte, indexLength)
 		n, err = io.ReadFull(r, buffer)
 		if err != nil || n < int(indexLength) {
 			return nil, fmt.Errorf("could not read index: %w", err)
 		}
 
-		prt, err := index.ReadPackedRTreeBytes(header.FeaturesCount(), header.IndexNodeSize(), buffer)
+		prt, err := index.ReadPackedRTreeBytes(header.FeaturesCount, header.IndexNodeSize, buffer)
 		if err != nil {
 			return nil, fmt.Errorf("could not read index: %w", err)
 		}
@@ -83,7 +83,7 @@ func NewFGB(r io.Reader) (*FGBReader, error) {
 	return &fgb, nil
 }
 
-func (fgb *FGBReader) Header() *FlatGeobuf.Header {
+func (fgb *FGBReader) Header() *FlatGeobuf.HeaderT {
 	return fgb.header
 }
 

--- a/generate_flatc.sh
+++ b/generate_flatc.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+flatc --go --gen-object-api fbs/feature.fbs fbs/header.fbs

--- a/properties.go
+++ b/properties.go
@@ -30,17 +30,17 @@ func (pd *PropertyDecoder) Decode(b []byte) map[string]interface{} {
 
 		val, size := pd.decodeVal(b[pos:], v)
 
-		res[string(v.Name())] = val
+		res[v.Name] = val
 		pos += size
 	}
 
 	return res
 }
 
-func (pd *PropertyDecoder) decodeVal(b []byte, v *FlatGeobuf.Column) (interface{}, uint16) {
+func (pd *PropertyDecoder) decodeVal(b []byte, v *FlatGeobuf.ColumnT) (interface{}, uint16) {
 	var val interface{}
 	var size uint16
-	switch v.Type() {
+	switch v.Type {
 	case FlatGeobuf.ColumnTypeByte:
 		val = int8(b[0])
 		size = 1


### PR DESCRIPTION
Changed all struct usage to be of `[objecttype]T` generated from gen-object-api. Some refactors can arise from this change, as some conversions and workarounds made can no longer be needed, but should that be a separate issue?